### PR TITLE
Rename entities to refer to rows and columns

### DIFF
--- a/src/entity/Door.java
+++ b/src/entity/Door.java
@@ -1,9 +1,9 @@
 package entity;
 
 public class Door extends Entity {
-    public Door(String name, char sprite, int xPosition, int yPosition){
+    public Door(String name, char sprite, int columnPosition, int rowPosition){
 
-        super(name,0,sprite,xPosition,yPosition,true);
+        super(name,0,sprite,columnPosition,rowPosition,true);
     }
 
 }

--- a/src/entity/Entity.java
+++ b/src/entity/Entity.java
@@ -8,12 +8,12 @@ public abstract class Entity {
     private char sprite;
     int[] position;
     private boolean canCollide;
-    Entity(String name,int movementSpeed,char sprite,int xPosition,int yPosition,boolean canCollide){
+    Entity(String name,int movementSpeed,char sprite,int columnPosition,int rowPosition,boolean canCollide){
         this.name = name;
         this.movementSpeed = movementSpeed;
         this.sprite = sprite;
         this.position = new int[2];
-        setPosition(xPosition,yPosition);
+        setPosition(columnPosition,rowPosition);
         this.canCollide = canCollide;
 
     }

--- a/src/entity/PlayerCharacter.java
+++ b/src/entity/PlayerCharacter.java
@@ -1,8 +1,8 @@
 package entity;
 
 public class PlayerCharacter extends Entity {
-    public PlayerCharacter(String entityName, int movementSpeed, char spriteChar, int xPosition, int yPosition, boolean canCollide){
-        super(entityName,movementSpeed,spriteChar,xPosition,yPosition,canCollide);
+    public PlayerCharacter(String entityName, int movementSpeed, char spriteChar, int columnPosition, int rowPosition, boolean canCollide){
+        super(entityName,movementSpeed,spriteChar,columnPosition,rowPosition,canCollide);
     }
 
 }


### PR DESCRIPTION
Rename any part of the code in the Entity class or subclasses, referring to xPosition and yPosition into columnPosition and rowPosition instead.